### PR TITLE
Pulsar 1.5 support

### DIFF
--- a/exporter.json
+++ b/exporter.json
@@ -3,7 +3,7 @@
     "name": "Android",
     "description": "Android token and style exporter",
     "source_dir": "src",
-    "version": "1.0.6",
+    "version": "1.1",
     "tags": [
         "Android",
         "Tokens",

--- a/src/exported_files/colors.pr
+++ b/src/exported_files/colors.pr
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-{[ const colorTokensTree = @ds.tokenGroupTreeByType("Color") /]}
+{[ const colorTokensTree = ds.tokenGroupTreeByType("Color") /]}
 {[ traverse colorTokensTree property subgroups into colorTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(colorTokenGroup) /]}
-  {[ const colorTokenInGroups = @ds.tokensByGroupId(colorTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(colorTokenGroup) /]}
+  {[ const colorTokenInGroups = ds.tokensByGroupId(colorTokenGroup.id) /]}
   {[ for colorToken in colorTokenInGroups ]}
-    {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, colorToken.name) /]}
-    {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ") /]}
-    {[ if @boolean.and(@compare.nonnull(colorToken.description), @boolean.not(@compare.equals(colorToken.description, ""))) ]}
+    {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, colorToken.name) /]}
+    {[ const fullTokenName = arrayJoin(fullTokenPath, " ") /]}
+    {[ if (colorToken.description && colorToken.description !== "") ]}
     <!-- 
-        {{ @js.indentMultilineText(colorToken.description, "        ") }} 
+        {{ indentMultilineText(colorToken.description, "        ") }} 
     -->
     {[/]}
     <color name="{[ inject "export_snakecased_token_name" context fullTokenName /]}">{[ inject "export_color_value" context colorToken.value /]}</color>

--- a/src/exported_files/dimens.pr
+++ b/src/exported_files/dimens.pr
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-{[ const measureTokensTree = @ds.tokenGroupTreeByType("Measure") /]}
+{[ const measureTokensTree = ds.tokenGroupTreeByType("Measure") /]}
 {[ traverse measureTokensTree property subgroups into measureTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(measureTokenGroup) /]}
-  {[ const measureTokenInGroups = @ds.tokensByGroupId(measureTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(measureTokenGroup) /]}
+  {[ const measureTokenInGroups = ds.tokensByGroupId(measureTokenGroup.id) /]}
   {[ for measureToken in measureTokenInGroups ]}
-    {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, measureToken.name) /]}
-    {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ") /]}
+    {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, measureToken.name) /]}
+    {[ const fullTokenName = arrayJoin(fullTokenPath, " ") /]}
 
-    {[ if @boolean.and(@compare.nonnull(measureToken.description), @boolean.not(@compare.equals(measureToken.description, ""))) ]}
+    {[ if (measureToken.description && measureToken.description !== "") ]}
     <!-- 
-        {{ @js.indentMultilineText(measureToken.description, "        ") }} 
+        {{ indentMultilineText(measureToken.description, "        ") }} 
     -->
     {[/]}
     <dimen name="{[ inject "export_snakecased_token_name" context fullTokenName /]}">{{ measureToken.value.measure }}dp</dimen>{[/]} 

--- a/src/exported_files/fonts.pr
+++ b/src/exported_files/fonts.pr
@@ -14,12 +14,12 @@
     {[ let subfamilyName = font.subfamily.snakecased()  /]}
     {[ let fontName = familyName.suffixed("_").suffixed(subfamilyName) /]}
     {[ let fontStyle = "normal" /]}
-    {[ if ds.fonts.isItalic(font) ]}
+    {[ if ds.isFontItalic(font) ]}
       {[ fontStyle = "italic" /]}
     {[/]}
     <font
         app:fontStyle="{{ fontStyle }}"
-        app:fontWeight="{{ ds.fonts.weight(font) }}"
+        app:fontWeight="{{ ds.fontWeight(font) }}"
         app:font="@font/{{ fontName }}" />
     {[/]}
 

--- a/src/exported_files/fonts.pr
+++ b/src/exported_files/fonts.pr
@@ -1,4 +1,4 @@
-{[ let familyToFonts = @js.groupFontsByFamily(context.values()) /]}
+{[ let familyToFonts = groupFontsByFamily(context.values()) /]}
 
 {[ let i = 0 /]}
 {[ for family in familyToFonts.keys() ]}
@@ -14,12 +14,12 @@
     {[ let subfamilyName = font.subfamily.snakecased()  /]}
     {[ let fontName = familyName.suffixed("_").suffixed(subfamilyName) /]}
     {[ let fontStyle = "normal" /]}
-    {[ if @ds.fonts.isItalic(font) ]}
-      {[ set fontStyle = "italic" /]}
+    {[ if ds.fonts.isItalic(font) ]}
+      {[ fontStyle = "italic" /]}
     {[/]}
     <font
         app:fontStyle="{{ fontStyle }}"
-        app:fontWeight="{{ @ds.fonts.weight(font) }}"
+        app:fontWeight="{{ ds.fonts.weight(font) }}"
         app:font="@font/{{ fontName }}" />
     {[/]}
 
@@ -27,5 +27,5 @@
 
   {[/]}
 
-  {[ set i = i.addedBy(1) /]}
+  {[ i = i.addedBy(1) /]}
 {[/]}

--- a/src/exported_files/radii.pr
+++ b/src/exported_files/radii.pr
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-{[ const radiusTokensTree = @ds.tokenGroupTreeByType("Radius") /]}
+{[ const radiusTokensTree = ds.tokenGroupTreeByType("Radius") /]}
 {[ traverse radiusTokensTree property subgroups into radiusTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(radiusTokenGroup) /]}
-  {[ const radiusTokenInGroups = @ds.tokensByGroupId(radiusTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(radiusTokenGroup) /]}
+  {[ const radiusTokenInGroups = ds.tokensByGroupId(radiusTokenGroup.id) /]}
   {[ for radiusToken in radiusTokenInGroups ]}
-    {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, radiusToken.name) /]}
-    {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ") /]}
+    {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, radiusToken.name) /]}
+    {[ const fullTokenName = arrayJoin(fullTokenPath, " ") /]}
     
-    {[ if @boolean.and(@compare.nonnull(radiusToken.description), @boolean.not(@compare.equals(radiusToken.description, ""))) ]}
+    {[ if (radiusToken.description && radiusToken.description !== "") ]}
     <!-- 
-        {{ @js.indentMultilineText(radiusToken.description, "        ") }} 
+        {{ indentMultilineText(radiusToken.description, "        ") }} 
     -->
     {[/]}
     <dimen name="{[ inject "export_snakecased_token_name" context fullTokenName /]}">{{ radiusToken.value.radius.measure }}dp</dimen>{[/]}

--- a/src/exported_files/text_styles.pr
+++ b/src/exported_files/text_styles.pr
@@ -1,42 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-{[ let fontsMap = @init.dictionary() /]}
-{[ const typographyTokensTree = @ds.tokenGroupTreeByType("Typography") /]}
+{[ let fontsMap = {} /]}
+{[ const typographyTokensTree = ds.tokenGroupTreeByType("Typography") /]}
 {[ traverse typographyTokensTree property subgroups into typographyTokenGroup ]}
-  {[ let fullTokenGroupPath = @js.createFullTokenGroupPath(typographyTokenGroup) /]}
-  {[ const typographyTokenInGroups = @ds.tokensByGroupId(typographyTokenGroup.id) /]}
+  {[ let fullTokenGroupPath = createFullTokenGroupPath(typographyTokenGroup) /]}
+  {[ const typographyTokenInGroups = ds.tokensByGroupId(typographyTokenGroup.id) /]}
   {[ for typographyToken in typographyTokenInGroups ]}
-    {[ const fullTokenPath = @js.arrayConcat(fullTokenGroupPath, typographyToken.name) /]}
-    {[ const fullTokenName = @js.arrayJoin(fullTokenPath, " ") /]}
+    {[ const fullTokenPath = arrayConcat(fullTokenGroupPath, typographyToken.name) /]}
+    {[ const fullTokenName = arrayJoin(fullTokenPath, " ") /]}
     
-    {[ if @boolean.and(@compare.nonnull(typographyToken.description), @boolean.not(@compare.equals(typographyToken.description, ""))) ]}
+    {[ if (typographyToken.description && typographyToken.description !== "") ]}
     <!-- 
-        {{ @js.indentMultilineText(typographyToken.description, "        ") }} 
+        {{ indentMultilineText(typographyToken.description, "        ") }} 
     -->
     {[/]}
     <style name="{[ inject "export_camelcased_token_name" context fullTokenName /]}">
         <item name="android:textSize">{{ typographyToken.value.fontSize.measure }}sp</item>
         {[ const letterSpacing = typographyToken.value.letterSpacing /]}
-        {[ if @compare.nonnull(letterSpacing) ]}
+        {[ if letterSpacing ]}
         <item name="android:letterSpacing">{{ letterSpacing.measure }}</item>
         {[/]}
         {[ const font = typographyToken.value.font /]}
-        {[ if @compare.nonnull(font) ]}
+        {[ if font ]}
           {[ let familyName = font.family.snakecased()()  /]}
           {[ let subfamilyName = font.subfamily.snakecased()  /]}
           {[ let fontName = familyName.suffixed("_").suffixed(subfamilyName) /]}
-          {[ set fontsMap = fontsMap.add(fontName, font) /]}
+          {[ fontsMap = fontsMap.add(fontName, font) /]}
         <item name="android:fontFamily">@font/{{ fontName }}</item>
           {[ let fontStyles = [] /]}
-          {[ if @ds.fonts.isItalic(font) ]}
-            {[ set fontStyles = @js.arrayConcat(fontStyles, "italic") /]}
+          {[ if ds.isFontItalic(font) ]}
+            {[ fontStyles = arrayConcat(fontStyles, "italic") /]}
           {[/]}
-          {[ if @ds.fonts.isBold(font) ]}
-            {[ set fontStyles = @js.arrayConcat(fontStyles, "bold") /]}
+          {[ if ds.isFontItalic(font) ]}
+            {[ fontStyles = arrayConcat(fontStyles, "bold") /]}
           {[/]}
-          {[ let textStyle = @js.arrayJoin(fontStyles, "|") /]}
-        <item name="android:textStyle">{[ if @compare.empty(textStyle) ]}normal{[ else ]}{{ textStyle }}{[/]}</item>
+          {[ let textStyle = arrayJoin(fontStyles, "|") /]}
+        <item name="android:textStyle">{{ (textStyle.count() === 0) ? "normal" : textStyle}}</item>
         {[/]}
     </style>
   {[/]}

--- a/src/utilities/export_token_name.pr
+++ b/src/utilities/export_token_name.pr
@@ -1,4 +1,4 @@
 {[ const tokenName = context /]}
 {[ const firstChar = tokenName.substring(0, 1) /]}
-{[ const isDigit = @js.isDigit(firstChar) /]}
+{[ const isDigit = isDigit(firstChar) /]}
 {[ if isDigit ]}_{[/]}{{ tokenName }}


### PR DESCRIPTION
This PR adds support for Pulsar 1.5

- All javascript calls now treated as top-level functions (no more `@js.` needed and will throw error if used) so all are reworked
- DS accessors are now proper methods on top-level `ds` object, so everything was reworked for this and autocomplete now properly works for those as well
- All ds methods are now actual methods, and can't have extra `.` inside it, so that was removed (for example, `@ds.fonts.isItalic` is now actually `ds.isFontItalic()`)
- Expressions have been simplified and syntax reworked to be aligned with new Pulsar, which follows JS syntax closely now
- Complex expressions inside flows must be surrounded with `()`, but expressions inside `{{ }}` don't need this, so reworked as well
- Added shorthands and object support, so you can use `{}` and `[]` to create empty objects and arrays, and all methods used previously to init etc. were removed

- Version of exporter bumped to next minor


Note for reviewer:
This PR CAN'T be merged and exporter run before Pulsar is merged to your environments, please don't merge it yourself.